### PR TITLE
[INFRA] Grafana SaaS 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,10 @@ dependencies {
 	//mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	//grafana
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     networks:
       - nuvibe-network
     restart: unless-stopped
+    volumes:
+      - ./logs:/logs
     logging:
       driver: "json-file"
       options:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,19 @@ jwt:
   access-token-validity: ${JWT_ACCESS_TOKEN_VALIDITY}
   refresh-token-validity: ${JWT_REFRESH_TOKEN_VALIDITY}
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health, info
+  metrics:
+    tags:
+      application: nuvibe
+
+logging:
+  file:
+    name: /logs/application.log
+
 frontend:
   url: ${FRONT_URL:http://localhost:3000}
   redirect:


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #53 

## 🔑 주요 내용

- 배포서버 모니터링용 grafana prometheus 및 loki 설정했습니다. t3.micro상 도커에 모니터링을 띄우는 건 어려워 SaaS를 통해 올렸습니다. 배포서버 로그 확인 및 cpu, 램 사용량 등을 확인 가능합니다.


## Check List

- [X] **Reviewers** 등록을 하였나요?
- [X] **Assignees** 등록을 하였나요?
- [X] **라벨(Label)** 등록을 하였나요?
- [X] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션 모니터링 및 성능 지표 수집 기능 추가

* **Chores**
  * 헬스 체크 및 모니터링 엔드포인트 설정 구성
  * 애플리케이션 로깅 및 저장소 인프라 구성

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->