### PR TITLE
chore #76: 이미지 태그 enum 수정

### DIFF
--- a/src/main/java/com/umc/nuvibe/domain/image/vo/ImageTag.java
+++ b/src/main/java/com/umc/nuvibe/domain/image/vo/ImageTag.java
@@ -311,7 +311,7 @@ public enum ImageTag {
             List.of("투명", "반사"),
             "투명함, 반사, 굴절이 동시에 존재하는 재질을 담습니다. 창 너머 풍경, 유리컵, 반사된 빛이 겹치는 장면을 기록해보세요."
     ),
-    PAPER(
+    Paper(
             ImageTagCategory.TEXTURE,
             "종이",
             List.of("페이퍼", "질감"),


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #76 

## 🔑 주요 내용

- 태그 이넘 첫 글자만 대문자로 수정하였습니다


## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

**Refactor**
- 이미지 태그 식별자의 명명 규칙을 CamelCase로 일관되게 변경하여 가독성과 일관성을 향상시켰습니다. 무드, 조명, 색상, 질감, 공간, 일상, 패션, 미디어, 여행 등 여러 카테고리의 태그명이 업데이트되었습니다. 태그에 연결된 카테고리, 한국어 레이블, 동의어 및 설명 등 메타데이터와 동작은 변경되지 않아 사용자 경험에는 영향이 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->