### PR TITLE
[REFACTOR] 아카이브 보드 이미지 페이징 조회 날짜 표기 수정

### DIFF
--- a/src/main/java/com/umc/nuvibe/domain/archive/dto/response/BoardImageResponse.java
+++ b/src/main/java/com/umc/nuvibe/domain/archive/dto/response/BoardImageResponse.java
@@ -12,6 +12,8 @@ public record BoardImageResponse(
     ImageTag tag,
     String uploadedAt
 ) {
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
+
     public static BoardImageResponse from(BoardImage boardImage) {
         return new BoardImageResponse(
             boardImage.getImage().getId(),
@@ -30,6 +32,6 @@ public record BoardImageResponse(
         long hours = duration.toHours();
         if (hours < 24) return String.format("%02dh", hours);
 
-        return uploadedAt.format(DateTimeFormatter.ofPattern("yy.MM.dd"));
+        return uploadedAt.format(DATE_FORMATTER);
     }
 }


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #75 

## 🔑 주요 내용

- 아카이브 보드 이미지 페이징 조회 날짜 표기 수정


## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **스타일**
  * 아카이브 이미지의 업로드 시간 표시 방식이 상대적 시간(예: "2시간 전")에서 고정된 날짜 형식(YY.MM.DD)으로 변경되었습니다. 기존의 세부 시간 표기는 간소화되어 모든 업로드 항목에 일관된 날짜 형식으로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->